### PR TITLE
Feat/support client credentials flow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,8 @@
 .claude
 .pytest_cache
 .ruff_cache
-*.sql
-*.sqlite3
-*.log
+.github
+**/*.sql
+**/*.sqlite3
+**/*.log
+**/.DS_Store

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ You can find the specs of the mappings here:
 
 ### Authenticating
 - **Login**: POST to `/token` with credentials (see the chapter on configuration)
+  - Credentials can be used with a `password` grant_type or a `client_credentials` grant_type.
 - **Token**: Include in `Authorization: Bearer <token>` header
 
 ### Creating shipments
@@ -200,12 +201,12 @@ All configuration is handled through environment variables that can be set via `
 ### Authentication
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `DEFAULT_USER` | `sandy` | Default username for token authentication |
-| `DEFAULT_PASSWORD` | `sandbox` | Default password for token authentication |
+| `DEFAULT_USER` | `sandy` | Default username or client_id for Oauth authentication |
+| `DEFAULT_PASSWORD` | `sandbox` | Default password or client_secret for Oauth authentication |
 | `WEBHOOK_API_KEY` | auto-generated | API key for webhook authentication |
 | `JWT_SECRET_KEY` | auto-generated | JWT signing key (randomly generated if not set) |
 | `JWT_ALGORITHM` | `HS256` | JWT signing algorithm |
-| `JWT_EXPIRE_MINUTES` | `15` | JWT token expiration time in minutes |
+| `JWT_EXPIRE_MINUTES` | `15` | JWT expiration time in minutes |
 
 ### Database
 | Variable | Default | Description |

--- a/integrationsandbox/security/controller.py
+++ b/integrationsandbox/security/controller.py
@@ -1,30 +1,89 @@
+import base64
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
-from fastapi.security import OAuth2PasswordRequestForm
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.security.utils import get_authorization_scheme_param
 
 from integrationsandbox.security.models import Token, User
 from integrationsandbox.security.service import get_current_active_user, login_user
 
+from .security import OAuth2TokenRequestForm
+
 router = APIRouter(tags=["System"])
 logger = logging.getLogger(__name__)
+
+"""
+ using the client_id and client_secret option as a front to username and password. 
+ For the sandbox to support both is fine. This is by no means a correct implementation of client grant.
+ /token will support form data method and basic auth method for OAuth 2.1 compliance.
+ """
 
 
 @router.post("/token")
 async def login_for_access_token(
-    form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
+    request: Request,
+    form_data: Annotated[OAuth2TokenRequestForm, Depends()],
 ) -> Token:
-    logger.info("Login attempt for user: %s", form_data.username)
-    token = login_user(form_data.username, form_data.password)
+    auth_username = None
+    auth_password = None
+
+    authorization = request.headers.get("Authorization")
+    if authorization:
+        scheme, credentials = get_authorization_scheme_param(authorization)
+        if scheme.lower() == "basic":
+            try:
+                decoded = base64.b64decode(credentials).decode("utf-8")
+                auth_username, auth_password = decoded.split(":", 1)
+            except (ValueError, UnicodeDecodeError):
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Invalid authorization header",
+                    headers={"WWW-Authenticate": "Basic"},
+                )
+
+    if form_data.grant_type == "client_credentials":
+        username = auth_username or form_data.client_id
+        password = auth_password or form_data.client_secret
+
+        if not username or not password:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Client credentials required",
+                headers={"WWW-Authenticate": "Basic"},
+            )
+
+        logger.info("Login attempt for client_credentials: %s", username)
+        token = login_user(username, password)
+
+    elif form_data.grant_type == "password":
+        username = form_data.username
+        password = form_data.password
+
+        if not username or not password:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Username and password required",
+            )
+
+        logger.info("Login attempt for password grant: %s", username)
+        token = login_user(username, password)
+
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unsupported grant_type: {form_data.grant_type}",
+        )
+
     if not token:
-        logger.warning("Login failed for user: %s", form_data.username)
+        logger.warning("Login failed for %s: %s", form_data.grant_type, username)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect username or password",
-            headers={"WWW-Authenticate": "Bearer"},
+            headers={"WWW-Authenticate": "Basic"},
         )
-    logger.info("Login successful for user: %s", form_data.username)
+
+    logger.info("Login successful for %s: %s", form_data.grant_type, username)
     return token
 
 

--- a/integrationsandbox/security/models.py
+++ b/integrationsandbox/security/models.py
@@ -17,4 +17,3 @@ class User(BaseModel):
 
 class UserInDB(User):
     hashed_password: str
-    hashed_password: str

--- a/integrationsandbox/security/security.py
+++ b/integrationsandbox/security/security.py
@@ -1,0 +1,61 @@
+from typing import Optional
+
+from fastapi import Form, HTTPException, Request
+from fastapi.openapi.models import OAuthFlowClientCredentials, OAuthFlows
+from fastapi.security import OAuth2
+from fastapi.security.utils import get_authorization_scheme_param
+from starlette.status import HTTP_401_UNAUTHORIZED
+
+
+class Oauth2ClientCredentials(OAuth2):
+    def __init__(
+        self,
+        token_url: str,
+        scheme_name: str = None,
+        scopes: dict = None,
+        auto_error: bool = True,
+    ):
+        if not scopes:
+            scopes = {}
+        flows = OAuthFlows(
+            clientCredentials=OAuthFlowClientCredentials(
+                tokenUrl=token_url, scopes=scopes
+            )
+        )
+        super().__init__(flows=flows, scheme_name=scheme_name, auto_error=auto_error)
+
+    async def __call__(self, request: Request) -> Optional[str]:
+        authorization: str = request.headers.get("Authorization")
+        scheme, param = get_authorization_scheme_param(authorization)
+        if not authorization or scheme.lower() != "bearer":
+            if self.auto_error:
+                raise HTTPException(
+                    status_code=HTTP_401_UNAUTHORIZED,
+                    detail="Not authenticated",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+            else:
+                return None
+        return param
+
+
+class OAuth2TokenRequestForm:
+    def __init__(
+        self,
+        grant_type: str = Form("password"),
+        scope: str = Form(""),
+        client_id: Optional[str] = Form(None),
+        client_secret: Optional[str] = Form(None),
+        username: Optional[str] = Form(None),
+        password: Optional[str] = Form(None),
+    ):
+        self.grant_type = grant_type
+        self.scopes = scope.split() if scope else []
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.username = username
+        self.password = password
+
+
+# not using any scopes now, but could be added here.
+oauth2_client_credentials_scheme = Oauth2ClientCredentials(token_url="token")

--- a/integrationsandbox/security/service.py
+++ b/integrationsandbox/security/service.py
@@ -5,17 +5,15 @@ from typing import Annotated
 import bcrypt
 import jwt
 from fastapi import Depends, HTTPException, status
-from fastapi.security import OAuth2PasswordBearer
 from jwt.exceptions import InvalidTokenError
 
 from integrationsandbox.config import get_settings
 from integrationsandbox.security import repository
 from integrationsandbox.security.models import Token, TokenData, User
+from integrationsandbox.security.security import oauth2_client_credentials_scheme
 
 settings = get_settings()
 logger = logging.getLogger(__name__)
-
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 
 
 def verify_password(plain_password, hashed_password):
@@ -71,7 +69,9 @@ def login_user(username: str, password: str) -> Token | None:
     return Token(access_token=access_token, token_type="bearer")
 
 
-async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]):
+async def get_current_user(
+    token: Annotated[str, Depends(oauth2_client_credentials_scheme)],
+):
     logger.debug("Validating JWT token")
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
@@ -79,6 +79,8 @@ async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]):
         headers={"WWW-Authenticate": "Bearer"},
     )
     try:
+        if not token:
+            raise credentials_exception
         payload = jwt.decode(
             token, settings.jwt_secret_key, algorithms=[settings.jwt_algorithm]
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "integration-sandbox"
-version = "v1.0.4"
+version = "v1.0.5"
 description = " A integration sandbox that provides mock endpoints to test against."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -291,7 +291,7 @@ wheels = [
 
 [[package]]
 name = "integration-sandbox"
-version = "1.0.4"
+version = "1.0.5"
 source = { virtual = "." }
 dependencies = [
     { name = "bcrypt" },


### PR DESCRIPTION
When testing out n8n I noticed that the Oauth password grant that I used was not supported. They follow the oauth 2.1 spec.

- Added support for the "client_grant" Oauth flow. Which is wired into the same backend logic that validates username and password.
- it is now possible to send client_id and client_secret as form data or as basic auth to get a JWT.
- Cleaned up .dockerignore.